### PR TITLE
fix: install bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.9
 
 RUN apk add --no-cache jq \
-    curl
+    curl \
+    bash
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Part of osp-cfc-platform/backlog#975

New base image doesn't have bash installed by default.